### PR TITLE
:sparkles: Index ページに単語一覧を表示する

### DIFF
--- a/Client/Pages/Index.razor
+++ b/Client/Pages/Index.razor
@@ -1,10 +1,47 @@
 ﻿@page "/"
+@using WordsCombiner.Shared
+@using WordsCombiner.Shared.Model
+@inject HttpClient Http
 
 <PageTitle>WordCominer</PageTitle>
 
 <h1>Word Cominer!</h1>
 <h3>複合連結型発想法を手軽におこなうためのアプリケーション</h3>
 
-Welcome to your new app.
+@if (words == null)
+{
+    <p><em>Loading...</em></p>
+}
+else
+{
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Id</th>
+                <th>単語</th>
+                <th>品詞</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var word in words)
+            {
+                var partOfSpeech = (PartOfSpeech)word.PartOfSpeech;
 
-<SurveyPrompt Title="How is Blazor working for you?" />
+                <tr>
+                    <td>@word.Id</td>
+                    <td>@word.Value</td>
+                    <td>@partOfSpeech</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+@code {
+    private Word[]?  words;
+
+    protected override async Task OnInitializedAsync()
+    {
+        words = await Http.GetFromJsonAsync<Word[]>("api/Words");
+    }
+}

--- a/Shared/PartOfSpeech.cs
+++ b/Shared/PartOfSpeech.cs
@@ -1,0 +1,20 @@
+﻿namespace WordsCombiner.Shared
+{
+    public enum PartOfSpeech
+    {
+        /// <summary>
+        /// 名詞。
+        /// </summary>
+        Noun = 0,
+
+        /// <summary>
+        /// 動詞。
+        /// </summary>
+        Verb = 1,
+
+        /// <summary>
+        /// 形容詞。
+        /// </summary>
+        Adjective = 2,
+    }
+}


### PR DESCRIPTION
### 関連

* https://example.com

### 概要

* index ページにDBから取得した単語の一覧を表示するようにした

### 前提条件

* 機能追加にあたっての全治条件があれば記載

### できるようになること

* ローカルのDBから単語を取得し、Index ページに表示

### できなくなること

* なし

### 動作確認

* ローカルにて動作確認
![image](https://user-images.githubusercontent.com/59964162/224476591-fc72c261-b833-4cd9-9004-551f4c7b300c.png)


### その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
